### PR TITLE
Include parameter-overrides example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Deploys AWS CloudFormation Stacks.
   with:
     name: MyStack
     template: myStack.yaml
+    parameter-overrides: "MyParam1=myValue,MyParam2=${{ secrets.MY_SECRET_VALUE }}"
 ```
 
 The action can be passed a CloudFormation Stack `name` and a `template` file. It will create the Stack if it does not exist, or create a [Change Set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html) to update the Stack. An update fails by default when the Change Set is empty. Setting `no-fail-on-empty-changeset: "1"` will override this behavior and not throw an error.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Added an example of how to use `parameter-overrides`. It wasn't obvious from README or from action.yml how to specify parameters for the Cloudformation stack. Digging through the source code revealed that the parameters need to be encoded as a comma-separated string. This change should help anyone else wondering how to specify stack parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
