### PR TITLE
(feat) set stack outputs as action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     default: "0"
 outputs:
   stack-id:
-    description: "The id of the deployed stack"
+    description: "The id of the deployed stack. In addition, any outputs declared in the deployed CloudFormation stack will also be set as outputs for the action, e.g. if the stack has a stack output named 'foo', this action will also have an output named 'foo'."
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -142,3 +142,21 @@ export async function deployStack(
     noEmptyChangeSet
   );
 }
+
+export async function getStackOutputs(
+  cfn: aws.CloudFormation,
+  stackId: string
+): Promise<Map<string, string>> {
+  const outputs = new Map<string, string>();
+  const stack = await getStack(cfn, stackId);
+
+  if (stack && stack.Outputs) {
+    for (const output of stack.Outputs) {
+      if (output.OutputKey && output.OutputValue) {
+        outputs.set(output.OutputKey, output.OutputValue);
+      }
+    }
+  }
+
+  return outputs;
+}


### PR DESCRIPTION
Any stack outputs will be set as action outputs

Example:
```
    - name: Deploy ECS Service with CloudFormation
      id: service-stack
      uses: aws-actions/aws-cloudformation-github-deploy@v1
      with:
        name: github-actions-service
        template: cloudformation-templates/service-fargate-public-subnet-public-lb.yml
        parameter-overrides: >-
          ImageUrl=nginx
    - name: Print service stack outputs
      env:
        OUTPUTS: ${{ toJson(steps.service-stack.outputs) }}
      run: echo "$OUTPUTS"
```

My CFN template has an output "ServiceURL", so this is the sample output:
```
{
  "stack-id": "arn:aws:cloudformation:***:***:stack/github-actions-service/53a97cb0-a2dd-11ea-b6d3-0608930970a0",
  "ServiceURL": "http://clare-Publi-E3GRD5LG86GN-138111391.us-east-1.elb.amazonaws.com"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
