### PR TITLE
Update Example when pointing parameter-overrides to a JSON file in the repository

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: "CAPABILITY_IAM"
   parameter-overrides:
-    description: 'The parameters to override in the stack inputs. You can pass a comma-delimited list or a file URL. Comma-delimited list has each entry formatted as <ParameterName>=<ParameterValue>. A JSON file can be a local file with a "file://" prefix or remote URL (e.g. file://github.workspace/variables.json or http://example.com/variables.json). A local file needs to be specified with an absolute path to it. The file should look like: [ { "ParameterKey": "KeyPairName", "ParameterValue": "MyKey" }]'
+    description: 'The parameters to override in the stack inputs. You can pass a comma-delimited list or a file URL. Comma-delimited list has each entry formatted as <ParameterName>=<ParameterValue>. A JSON file can be a local file with a "file://" prefix or remote URL (e.g. file:///${{ github.workspace }}/variables.json or http://example.com/variables.json). A local file needs to be specified with an absolute path to it. The file should look like: [ { "ParameterKey": "KeyPairName", "ParameterValue": "MyKey" }]'
     required: false
   no-execute-changeset:
     description: "Indicates whether to execute to the change set or have it reviewed. Default to '0' (will execute the change set)"


### PR DESCRIPTION
Does not work with example given. So updated the example when pointing to a file in the repo.

*Issue #, if available:*

Does not work with: file://github.workspace/variables.json

*Description of changes:*

Changed the example on how to refer to a parameter file within the repository

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
