### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ jobs:
       run: |
         ENVIRONMENT=`echo $REPO | tr "/" "-"`
         echo "Environment name: $ENVIRONMENT"
-        echo "::set-output name=environment::$ENVIRONMENT"
+        echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
 
     - name: Deploy Amazon EKS Cluster
       id: eks-cluster


### PR DESCRIPTION
*Issue #, if available:*

Resolve #84 

*Description of changes:*

Update the examples inside the `README.md` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
