### PR TITLE
fix: Ensure ChangesetName is optional

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1215,8 +1215,8 @@ describe('Deploy CloudFormation Stack', () => {
     const inputs: Inputs = {
       name: 'MockStack',
       template: 'template.yaml',
-      'change-set-name': 'Build-213123123-CS',
       capabilities: 'CAPABILITY_IAM',
+      'change-set-name': 'Build-213123123-CS',
       'parameter-overrides': 'AdminEmail=no-reply@amazon.com',
       'no-fail-on-empty-changeset': '1'
     }

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1211,4 +1211,57 @@ describe('Deploy CloudFormation Stack', () => {
 
     expect(core.setFailed).toBeCalled()
   })
+  test('deploy using a custom change-set name', async () => {
+    const inputs: Inputs = {
+      name: 'MockStack',
+      template: 'template.yaml',
+      'change-set-name': 'Build-213123123-CS',
+      capabilities: 'CAPABILITY_IAM',
+      'parameter-overrides': 'AdminEmail=no-reply@amazon.com',
+      'no-fail-on-empty-changeset': '1'
+    }
+    jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+      return inputs[name]
+    })
+    mockDescribeStacks.mockReset()
+    mockDescribeStacks.mockImplementation(() => {
+      return {
+        promise(): Promise<aws.CloudFormation.Types.DescribeStacksOutput> {
+          return Promise.resolve({
+            Stacks: [
+              {
+                StackId:
+                  'arn:aws:cloudformation:us-east-1:123456789012:stack/myteststack/466df9e0-0dff-08e3-8e2f-5088487c4896',
+                Tags: [],
+                Outputs: [],
+                StackStatusReason: '',
+                CreationTime: new Date('2013-08-23T01:02:15.422Z'),
+                Capabilities: [],
+                StackName: 'MockStack',
+                StackStatus: 'CREATE_COMPLETE'
+              }
+            ]
+          })
+        }
+      }
+    })
+    await run()
+    expect(core.setFailed).toHaveBeenCalledTimes(0)
+    expect(mockCreateChangeSet).toHaveBeenNthCalledWith(1, {
+      StackName: 'MockStack',
+      TemplateBody: mockTemplate,
+      Capabilities: ['CAPABILITY_IAM'],
+      Parameters: [
+        { ParameterKey: 'AdminEmail', ParameterValue: 'no-reply@amazon.com' }
+      ],
+      ChangeSetName: 'Build-213123123-CS',
+      NotificationARNs: undefined,
+      ResourceTypes: undefined,
+      RollbackConfiguration: undefined,
+      RoleARN: undefined,
+      Tags: undefined,
+      TemplateURL: undefined,
+      TimeoutInMinutes: undefined
+    })
+  })
 })

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   name:
     description: "The name of the CloudFormation stack"
     required: true
+  change-set-name:
+    description: "The name of the change set. The name must be unique among all change sets that are associated with the specified stack."
+    required: false
   template:
     description: "The path or URL to the CloudFormation template"
     required: true

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -123,6 +123,7 @@ async function getStack(
 export async function deployStack(
   cfn: aws.CloudFormation,
   params: CreateStackInput,
+  changeSetName: string,
   noEmptyChangeSet: boolean,
   noExecuteChangeSet: boolean,
   noDeleteFailedChangeSet: boolean
@@ -144,7 +145,7 @@ export async function deployStack(
     cfn,
     stack,
     {
-      ChangeSetName: `${params.StackName}-CS`,
+      ChangeSetName: changeSetName,
       ...{
         StackName: params.StackName,
         TemplateBody: params.TemplateBody,

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,6 @@ export type Inputs = {
 const clientConfiguration = {
   customUserAgent: 'aws-cloudformation-github-deploy-for-github-actions'
 }
-
 export async function run(): Promise<void> {
   try {
     const { GITHUB_WORKSPACE = __dirname } = process.env
@@ -37,6 +36,9 @@ export async function run(): Promise<void> {
     // Get inputs
     const template = core.getInput('template', { required: true })
     const stackName = core.getInput('name', { required: true })
+    const changeSetName = core.getInput('change-set-name', {
+      required: false
+    })
     const capabilities = core.getInput('capabilities', {
       required: false
     })
@@ -128,6 +130,7 @@ export async function run(): Promise<void> {
     const stackId = await deployStack(
       cfn,
       params,
+      changeSetName ? changeSetName : `${params.StackName}-CS`,
       noEmptyChangeSet,
       noExecuteChangeSet,
       noDeleteFailedChangeSet


### PR DESCRIPTION
issue: https://github.com/aws-actions/aws-cloudformation-github-deploy/pull/113#issuecomment-1854783445
*Description of changes:*

Adding changeSetName as a parameter in the deployStack function, if change-set-name is not provided we pass a default value which in this case is `${params.StackName}-CS`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
