### PR TITLE
Update exception in getStack for SDK v3

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -11,7 +11,7 @@ import {
   ExecuteChangeSetCommand,
   DescribeStacksCommand,
   CreateStackCommand,
-  StackNotFoundException
+  CloudFormationServiceException
 } from '@aws-sdk/client-cloudformation'
 import { CreateChangeSetInput, CreateStackInput } from './main'
 
@@ -129,7 +129,7 @@ async function getStack(
 
     return stacks.Stacks?.[0]
   } catch (e) {
-    if (e instanceof StackNotFoundException) {
+    if (e instanceof CloudFormationServiceException) {
       return undefined
     }
     throw e


### PR DESCRIPTION
*Issue #127*

*Description of changes:*
Adjusted for SDK v3 compatibility
See [API documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/DescribeStacksCommand/), `Throws` section

For testing I've hardcoded my stack details and added `console.log(e)`
Error in `catch` block looks like this:
```md
CloudFormationServiceException [ValidationError]: Stack with id test-prod-vpc does not exist
    at throwDefaultError (/home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@smithy/smithy-client/dist-cjs/default-error-handler.js:8:22)
    at /home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@smithy/smithy-client/dist-cjs/default-error-handler.js:18:39
    at de_DescribeStacksCommandError (/home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@aws-sdk/client-cloudformation/dist-cjs/protocols/Aws_query.js:1727:12)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@smithy/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24
    at async /home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@aws-sdk/middleware-signing/dist-cjs/awsAuthMiddleware.js:30:20
    at async /home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@smithy/middleware-retry/dist-cjs/retryMiddleware.js:31:46
    at async /home/user/Code/libs/aws-cloudformation-github-deploy/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26 {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: '4995d2b8-****-****-****-30e1de77fc62',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  Type: 'Sender',
  Code: 'ValidationError'
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
