### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-actions-aws-cloudformation-github-deploy",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-actions-aws-cloudformation-github-deploy",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-actions-aws-cloudformation-github-deploy",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Deploys a AWS CloudFormation stack",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
Bump package.json and package-lock.json version to 2.1.0 for release.

After merge:
1. `git tag v2.1.0` on master and push to trigger release workflow
2. Update `v2` tag to point to `v2.1.0`