### PR TITLE
fix: incomplete event monitoring logs

### DIFF
--- a/__tests__/event-streaming.test.ts
+++ b/__tests__/event-streaming.test.ts
@@ -326,6 +326,63 @@ describe('EventPoller Implementation', () => {
       const retrievedTime = eventPoller.getDeploymentStartTime()
       expect(retrievedTime).toEqual(testTime)
     })
+
+    it('should not drop events with the same timestamp', () => {
+      eventPoller.setDeploymentStartTime(new Date('2022-12-31T23:59:59Z'))
+
+      const sameTime = new Date('2023-01-01T10:00:00Z')
+      const events: StackEvent[] = [
+        {
+          EventId: 'evt-1',
+          Timestamp: sameTime,
+          LogicalResourceId: 'Resource1',
+          ResourceStatus: 'UPDATE_IN_PROGRESS'
+        },
+        {
+          EventId: 'evt-2',
+          Timestamp: sameTime,
+          LogicalResourceId: 'Resource2',
+          ResourceStatus: 'UPDATE_IN_PROGRESS'
+        }
+      ]
+
+      let newEvents = eventPoller['filterNewEvents'](events)
+      expect(newEvents).toHaveLength(2)
+      eventPoller['updateEventTracking'](newEvents)
+
+      // Third event at same timestamp arrives later
+      const laterBatch: StackEvent[] = [
+        ...events,
+        {
+          EventId: 'evt-3',
+          Timestamp: sameTime,
+          LogicalResourceId: 'Resource3',
+          ResourceStatus: 'UPDATE_IN_PROGRESS'
+        }
+      ]
+      newEvents = eventPoller['filterNewEvents'](laterBatch)
+      expect(newEvents).toHaveLength(1)
+      expect(newEvents[0].LogicalResourceId).toBe('Resource3')
+    })
+
+    it('should use EventId for dedup when available', () => {
+      eventPoller.setDeploymentStartTime(new Date('2022-12-31T23:59:59Z'))
+
+      const event: StackEvent = {
+        EventId: 'unique-uuid-123',
+        Timestamp: new Date('2023-01-01T10:00:00Z'),
+        LogicalResourceId: 'Resource1',
+        ResourceStatus: 'CREATE_IN_PROGRESS'
+      }
+
+      let newEvents = eventPoller['filterNewEvents']([event])
+      expect(newEvents).toHaveLength(1)
+      eventPoller['updateEventTracking'](newEvents)
+
+      // Same EventId should be deduped
+      newEvents = eventPoller['filterNewEvents']([event])
+      expect(newEvents).toHaveLength(0)
+    })
   })
 
   describe('API integration', () => {
@@ -349,7 +406,10 @@ describe('EventPoller Implementation', () => {
 
       expect(mockClient.send).toHaveBeenCalledWith(
         expect.objectContaining({
-          input: { StackName: 'test-stack', ChangeSetName: undefined }
+          input: {
+            StackName: 'test-stack',
+            NextToken: undefined
+          }
         })
       )
       expect(events).toHaveLength(1)
@@ -382,6 +442,54 @@ describe('EventPoller Implementation', () => {
       mockClient.send.mockRejectedValue(genericError)
 
       await expect(eventPoller.pollEvents()).rejects.toThrow(genericError)
+    })
+
+    it('should paginate and stop when hitting a seen EventId', async () => {
+      eventPoller.setDeploymentStartTime(new Date('2022-12-31T23:59:59Z'))
+
+      // First poll: seed with one event
+      mockClient.send.mockResolvedValueOnce({
+        OperationEvents: [
+          {
+            EventId: 'evt-old',
+            Timestamp: new Date('2023-01-01T10:00:00Z'),
+            LogicalResourceId: 'Resource1',
+            ResourceStatus: 'CREATE_IN_PROGRESS'
+          }
+        ]
+      })
+      await eventPoller.pollEvents()
+
+      // Second poll: page 1 has new event + NextToken, page 2 starts with the old event
+      mockClient.send
+        .mockResolvedValueOnce({
+          OperationEvents: [
+            {
+              EventId: 'evt-new',
+              Timestamp: new Date('2023-01-01T10:01:00Z'),
+              LogicalResourceId: 'Resource2',
+              ResourceStatus: 'CREATE_COMPLETE'
+            }
+          ],
+          NextToken: 'page2'
+        })
+        .mockResolvedValueOnce({
+          OperationEvents: [
+            {
+              EventId: 'evt-old',
+              Timestamp: new Date('2023-01-01T10:00:00Z'),
+              LogicalResourceId: 'Resource1',
+              ResourceStatus: 'CREATE_IN_PROGRESS'
+            }
+          ],
+          NextToken: 'page3'
+        })
+
+      const events = await eventPoller.pollEvents()
+      // Should stop at page 2 (hit seen event), not fetch page 3
+      expect(mockClient.send).toHaveBeenCalledTimes(3) // 1 initial + 2 second poll
+      expect(events).toHaveLength(1)
+      expect(events[0].LogicalResourceId).toBe('Resource2')
     })
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -74685,12 +74685,29 @@ class EventPollerImpl {
     pollEvents() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const command = new client_cloudformation_1.DescribeEventsCommand({
-                    StackName: this.stackName
-                });
-                const response = yield this.client.send(command);
-                const allEvents = response.OperationEvents || [];
-                // Filter for new events only (client-side filtering by time)
+                let allEvents = [];
+                let nextToken;
+                let hitSeenEvent = false;
+                // Paginate, but stop early when we hit an event we've already seen
+                // (API returns newest-first, so older = already processed)
+                do {
+                    const command = new client_cloudformation_1.DescribeEventsCommand({
+                        StackName: this.stackName,
+                        NextToken: nextToken
+                    });
+                    const response = yield this.client.send(command);
+                    const pageEvents = response.OperationEvents || [];
+                    for (const event of pageEvents) {
+                        const eventId = event.EventId || this.createEventId(event);
+                        if (this.seenEventIds.has(eventId)) {
+                            hitSeenEvent = true;
+                            break;
+                        }
+                        allEvents.push(event);
+                    }
+                    nextToken = hitSeenEvent ? undefined : response.NextToken;
+                } while (nextToken);
+                // Filter for deployment time window
                 const newEvents = this.filterNewEvents(allEvents);
                 if (newEvents.length > 0) {
                     // Reset interval when new events are found
@@ -74856,14 +74873,9 @@ class EventPollerImpl {
             if (event.Timestamp && event.Timestamp < deploymentStartWithBuffer) {
                 continue;
             }
-            // Create unique event ID from timestamp + resource + status
-            const eventId = this.createEventId(event);
+            const eventId = event.EventId || this.createEventId(event);
             if (!this.seenEventIds.has(eventId)) {
-                // Check if event is newer than our last seen timestamp
-                if (!this.lastEventTimestamp ||
-                    (event.Timestamp && event.Timestamp > this.lastEventTimestamp)) {
-                    newEvents.push(event);
-                }
+                newEvents.push(event);
             }
         }
         // Sort by timestamp (oldest first) for proper display order
@@ -74878,7 +74890,7 @@ class EventPollerImpl {
      */
     updateEventTracking(newEvents) {
         for (const event of newEvents) {
-            const eventId = this.createEventId(event);
+            const eventId = event.EventId || this.createEventId(event);
             this.seenEventIds.add(eventId);
             // Update last seen timestamp
             if (event.Timestamp &&

--- a/src/event-streaming.ts
+++ b/src/event-streaming.ts
@@ -12,6 +12,7 @@ import * as core from '@actions/core'
  * Includes both StackEvent and OperationEvent fields
  */
 export interface StackEvent {
+  EventId?: string
   Timestamp?: Date
   LogicalResourceId?: string
   ResourceType?: string
@@ -506,14 +507,34 @@ export class EventPollerImpl implements EventPoller {
    */
   async pollEvents(): Promise<StackEvent[]> {
     try {
-      const command = new DescribeEventsCommand({
-        StackName: this.stackName
-      })
+      let allEvents: StackEvent[] = []
+      let nextToken: string | undefined
+      let hitSeenEvent = false
 
-      const response = await this.client.send(command)
-      const allEvents = response.OperationEvents || []
+      // Paginate, but stop early when we hit an event we've already seen
+      // (API returns newest-first, so older = already processed)
+      do {
+        const command = new DescribeEventsCommand({
+          StackName: this.stackName,
+          NextToken: nextToken
+        })
 
-      // Filter for new events only (client-side filtering by time)
+        const response = await this.client.send(command)
+        const pageEvents = response.OperationEvents || []
+
+        for (const event of pageEvents) {
+          const eventId = event.EventId || this.createEventId(event)
+          if (this.seenEventIds.has(eventId)) {
+            hitSeenEvent = true
+            break
+          }
+          allEvents.push(event)
+        }
+
+        nextToken = hitSeenEvent ? undefined : response.NextToken
+      } while (nextToken)
+
+      // Filter for deployment time window
       const newEvents = this.filterNewEvents(allEvents)
 
       if (newEvents.length > 0) {
@@ -746,17 +767,10 @@ export class EventPollerImpl implements EventPoller {
         continue
       }
 
-      // Create unique event ID from timestamp + resource + status
-      const eventId = this.createEventId(event)
+      const eventId = event.EventId || this.createEventId(event)
 
       if (!this.seenEventIds.has(eventId)) {
-        // Check if event is newer than our last seen timestamp
-        if (
-          !this.lastEventTimestamp ||
-          (event.Timestamp && event.Timestamp > this.lastEventTimestamp)
-        ) {
-          newEvents.push(event)
-        }
+        newEvents.push(event)
       }
     }
 
@@ -772,7 +786,7 @@ export class EventPollerImpl implements EventPoller {
    */
   private updateEventTracking(newEvents: StackEvent[]): void {
     for (const event of newEvents) {
-      const eventId = this.createEventId(event)
+      const eventId = event.EventId || this.createEventId(event)
       this.seenEventIds.add(eventId)
 
       // Update last seen timestamp


### PR DESCRIPTION
## Summary

Fixes event monitoring dropping events during deployment, causing incomplete logs.

Closes #195

## Root Causes

1. **Strict timestamp comparison dropped concurrent events** — `filterNewEvents` required `event.Timestamp > lastEventTimestamp`, silently dropping events at the same second. CloudFormation frequently updates multiple resources simultaneously.

2. **No pagination** — `pollEvents` only fetched the first page of `DescribeEvents` results, missing events on subsequent pages for large stacks.

3. **Fragile dedup key** — Used a composite `timestamp-resourceId-status` key instead of the API-provided `EventId` UUID.

## Changes

- **Use `EventId`** from the API for deduplication (with composite key fallback)
- **Remove strict timestamp gate** — rely solely on `EventId` set for dedup
- **Add pagination** with early exit when hitting a seen `EventId` (API returns newest-first)
- **Add `EventId` to `StackEvent` interface**

## Testing

- 209 tests pass (3 new: same-timestamp events, EventId dedup, pagination early exit)
- Verified API behavior against live stacks: confirmed reverse-chronological order and `EventId` availability