### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-27
+
+### Features
+
+- **S3 Template Upload**: Added `s3-bucket` and `s3-prefix` inputs to automatically upload large templates to S3 before creating change sets, avoiding the 51,200 byte inline template limit (#180, #196)
+
+### Bug Fixes
+
+- **Incomplete Event Monitoring**: Fixed event streaming dropping concurrent events that shared the same timestamp. Now uses API-provided `EventId` for deduplication and paginates through all events (#195, #197)
+
 ## [2.1.0] - 2026-04-01
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-actions-aws-cloudformation-github-deploy",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Deploys a AWS CloudFormation stack",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
## Release v2.2.0

Updates CHANGELOG.md and package.json version for the v2.2.0 release.

### What's included

- **feat**: S3 template upload via `s3-bucket` and `s3-prefix` inputs (#196)
- **fix**: Incomplete event monitoring logs (#197)

### After merge

Tag the merge commit:
```bash
git tag v2.2.0
git tag -f v2
git push upstream v2.2.0
git push upstream v2 --force
```