### PR TITLE
Fix/monitoring nested stack events

### DIFF
--- a/__tests__/event-streaming-coverage.test.ts
+++ b/__tests__/event-streaming-coverage.test.ts
@@ -715,7 +715,7 @@ describe('Event Streaming Coverage Tests', () => {
             OperationEvents: [
               {
                 Timestamp: new Date(),
-                LogicalResourceId: 'TestStack',
+                LogicalResourceId: 'test-stack',
                 ResourceType: 'AWS::CloudFormation::Stack',
                 ResourceStatus: 'CREATE_COMPLETE'
               }
@@ -743,6 +743,41 @@ describe('Event Streaming Coverage Tests', () => {
       expect(mockCoreDebug).toHaveBeenCalledWith(
         'Event monitoring polling loop completed normally'
       )
+    }, 10000)
+
+    test('should not stop monitoring when a nested stack reaches terminal state', async () => {
+      const mockClient = {
+        send: jest.fn().mockResolvedValue({
+          OperationEvents: [
+            {
+              Timestamp: new Date(),
+              LogicalResourceId: 'NestedStack1',
+              ResourceType: 'AWS::CloudFormation::Stack',
+              ResourceStatus: 'CREATE_COMPLETE'
+            }
+          ]
+        })
+      }
+
+      const config: EventMonitorConfig = {
+        stackName: 'my-parent-stack',
+        client: mockClient as any,
+        enableColors: true,
+        pollIntervalMs: 50,
+        maxPollIntervalMs: 1000
+      }
+
+      const monitor = new EventMonitorImpl(config)
+
+      const monitorPromise = monitor.startMonitoring()
+
+      // Wait long enough for several polls to have processed the nested stack event
+      await new Promise(resolve => setTimeout(resolve, 200))
+
+      expect(monitor.isMonitoring()).toBe(true)
+
+      monitor.stopMonitoring()
+      await monitorPromise
     }, 10000)
 
     test('should handle empty events array in formatEvents', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -75147,15 +75147,16 @@ class EventMonitorImpl {
         }).length;
     }
     /**
-     * Check if any event indicates a terminal stack state
-     * Only considers the main stack events, not individual resources
+     * Check if any event indicates a terminal stack state.
+     * Only considers events for the root stack itself, not nested stack resources.
      */
     hasTerminalEvent(events) {
         return events.some(event => {
             const status = event.ResourceStatus || '';
             const resourceType = event.ResourceType || '';
-            // Only check terminal states for the main CloudFormation stack
-            if (resourceType === 'AWS::CloudFormation::Stack') {
+            const logicalId = event.LogicalResourceId || '';
+            if (resourceType === 'AWS::CloudFormation::Stack' &&
+                logicalId === this.config.stackName) {
                 return exports.TERMINAL_STACK_STATES.includes(status);
             }
             return false;

--- a/src/event-streaming.ts
+++ b/src/event-streaming.ts
@@ -1111,16 +1111,19 @@ export class EventMonitorImpl implements EventMonitor {
   }
 
   /**
-   * Check if any event indicates a terminal stack state
-   * Only considers the main stack events, not individual resources
+   * Check if any event indicates a terminal stack state.
+   * Only considers events for the root stack itself, not nested stack resources.
    */
   private hasTerminalEvent(events: StackEvent[]): boolean {
     return events.some(event => {
       const status = event.ResourceStatus || ''
       const resourceType = event.ResourceType || ''
+      const logicalId = event.LogicalResourceId || ''
 
-      // Only check terminal states for the main CloudFormation stack
-      if (resourceType === 'AWS::CloudFormation::Stack') {
+      if (
+        resourceType === 'AWS::CloudFormation::Stack' &&
+        logicalId === this.config.stackName
+      ) {
         return TERMINAL_STACK_STATES.includes(status as TerminalStackState)
       }
 


### PR DESCRIPTION
Use the resource ID of the terminal event to only flag it if it's for the main stack

*Issue #, if available:*

#201

*Description of changes:*

Previously the event monitoring would stop as soon as it encountered a terminal event for *any* stack, including nested stacks. This change makes it check against the main stack name so that it only stops if the event matches the parent stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
