### PR TITLE
feat: add max-attempts and retry-mode input parameters

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isUrl,
   parseParameters,
   parseBoolean,
+  parseRetryMode,
   withRetry
 } from '../src/utils'
 import * as path from 'path'
@@ -470,6 +471,30 @@ describe('withRetry', () => {
 
     await expect(withRetry(operation)).rejects.toThrow('Other error')
     expect(operation).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('parseRetryMode', () => {
+  test('returns "standard" for valid input', () => {
+    expect(parseRetryMode('standard')).toBe('standard')
+  })
+
+  test('returns "adaptive" for valid input', () => {
+    expect(parseRetryMode('adaptive')).toBe('adaptive')
+  })
+
+  test('throws on invalid input', () => {
+    expect(() => parseRetryMode('exponential')).toThrow(
+      "Invalid retry-mode: exponential. Supported values: 'standard', 'adaptive'."
+    )
+  })
+
+  test('returns undefined for empty string', () => {
+    expect(parseRetryMode('')).toBeUndefined()
+  })
+
+  test('returns undefined for undefined', () => {
+    expect(parseRetryMode(undefined)).toBeUndefined()
   })
 })
 

--- a/__tests__/validation.test.ts
+++ b/__tests__/validation.test.ts
@@ -1,0 +1,90 @@
+import { validateAndParseInputs } from '../src/validation'
+
+const baseInputs = {
+  mode: 'create-and-execute',
+  name: 'TestStack',
+  template: 'template.yaml',
+  capabilities: 'CAPABILITY_IAM',
+  'parameter-overrides': '',
+  'fail-on-empty-changeset': '1',
+  'no-execute-changeset': '0',
+  'no-delete-failed-changeset': '0',
+  'disable-rollback': '0',
+  'timeout-in-minutes': '',
+  'notification-arns': '',
+  'role-arn': '',
+  tags: '',
+  'termination-protection': '',
+  'http-proxy': '',
+  'change-set-name': '',
+  'include-nested-stacks-change-set': '0',
+  'deployment-mode': '',
+  's3-bucket': '',
+  's3-prefix': '',
+  'execute-change-set-id': '',
+  'max-attempts': '',
+  'retry-mode': ''
+}
+
+describe('validateAndParseInputs', () => {
+  describe('max-attempts', () => {
+    test('parses a valid number string', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'max-attempts': '10'
+      })
+      expect(result['max-attempts']).toBe(10)
+    })
+
+    test('returns undefined for empty string', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'max-attempts': ''
+      })
+      expect(result['max-attempts']).toBeUndefined()
+    })
+
+    test('returns undefined when not provided', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'max-attempts': undefined
+      })
+      expect(result['max-attempts']).toBeUndefined()
+    })
+  })
+
+  describe('retry-mode', () => {
+    test('parses "standard" correctly', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'retry-mode': 'standard'
+      })
+      expect(result['retry-mode']).toBe('standard')
+    })
+
+    test('parses "adaptive" correctly', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'retry-mode': 'adaptive'
+      })
+      expect(result['retry-mode']).toBe('adaptive')
+    })
+
+    test('returns undefined for empty string', () => {
+      const result = validateAndParseInputs({
+        ...baseInputs,
+        'retry-mode': ''
+      })
+      expect(result['retry-mode']).toBeUndefined()
+    })
+
+    test('throws on invalid retry-mode', () => {
+      expect(() =>
+        validateAndParseInputs({
+          ...baseInputs,
+          'retry-mode': 'exponential'
+        })
+      ).toThrow()
+    })
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,12 @@ inputs:
   s3-prefix:
     description: "A prefix to use for the S3 object key when uploading the template. The final key will be '<s3-prefix>/<template-filename>'. Defaults to no prefix."
     required: false
+  max-attempts:
+    description: "The maximum number of retry attempts for AWS API calls. Defaults to the AWS SDK default (3)."
+    required: false
+  retry-mode:
+    description: "The retry mode for AWS API calls. Supported values: 'standard', 'adaptive'. Defaults to the AWS SDK default ('standard')."
+    required: false
   deployment-mode:
     description: "The deployment mode for the change set. Use 'REVERT_DRIFT' to create a change set that reverts drift. Defaults to standard deployment."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -75609,6 +75609,8 @@ function run() {
                 'deployment-mode': core.getInput('deployment-mode', { required: false }),
                 's3-bucket': core.getInput('s3-bucket', { required: false }),
                 's3-prefix': core.getInput('s3-prefix', { required: false }),
+                'max-attempts': core.getInput('max-attempts', { required: false }),
+                'retry-mode': core.getInput('retry-mode', { required: false }),
                 'execute-change-set-id': core.getInput('execute-change-set-id', {
                     required: false
                 })
@@ -75623,6 +75625,12 @@ function run() {
                         httpsAgent: agent
                     })
                 });
+            }
+            if (inputs['max-attempts']) {
+                clientConfiguration = Object.assign(Object.assign({}, clientConfiguration), { maxAttempts: inputs['max-attempts'] });
+            }
+            if (inputs['retry-mode']) {
+                clientConfiguration = Object.assign(Object.assign({}, clientConfiguration), { retryMode: inputs['retry-mode'] });
             }
             const cfn = new client_cloudformation_1.CloudFormationClient(Object.assign({}, clientConfiguration));
             // Execute existing change set mode
@@ -75858,6 +75866,7 @@ exports.parseString = parseString;
 exports.parseNumber = parseNumber;
 exports.parseBoolean = parseBoolean;
 exports.parseParameters = parseParameters;
+exports.parseRetryMode = parseRetryMode;
 exports.parseDeploymentMode = parseDeploymentMode;
 exports.withRetry = withRetry;
 exports.configureProxy = configureProxy;
@@ -75969,6 +75978,16 @@ function parseParameters(parameterOverrides) {
         };
     });
 }
+function parseRetryMode(s) {
+    const parsed = parseString(s);
+    if (!parsed) {
+        return undefined;
+    }
+    if (parsed === 'standard' || parsed === 'adaptive') {
+        return parsed;
+    }
+    throw new Error(`Invalid retry-mode: ${parsed}. Supported values: 'standard', 'adaptive'.`);
+}
 function parseDeploymentMode(s) {
     const parsed = parseString(s);
     if (!parsed) {
@@ -76048,7 +76067,9 @@ const baseSchema = zod_1.z.object({
         .enum(['create-and-execute', 'create-only', 'execute-only'])
         .default('create-and-execute'),
     name: zod_1.z.string().min(1, 'Stack name is required'),
-    'http-proxy': zod_1.z.string().optional().transform(emptyToUndefined)
+    'http-proxy': zod_1.z.string().optional().transform(emptyToUndefined),
+    'max-attempts': zod_1.z.string().optional().transform(utils_1.parseNumber),
+    'retry-mode': zod_1.z.string().optional().transform(utils_1.parseRetryMode)
 });
 const createSchema = baseSchema.extend({
     mode: zod_1.z.enum(['create-and-execute', 'create-only']),

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,8 @@ export async function run(): Promise<void> {
       'deployment-mode': core.getInput('deployment-mode', { required: false }),
       's3-bucket': core.getInput('s3-bucket', { required: false }),
       's3-prefix': core.getInput('s3-prefix', { required: false }),
+      'max-attempts': core.getInput('max-attempts', { required: false }),
+      'retry-mode': core.getInput('retry-mode', { required: false }),
       'execute-change-set-id': core.getInput('execute-change-set-id', {
         required: false
       })
@@ -110,6 +112,20 @@ export async function run(): Promise<void> {
             httpsAgent: agent
           })
         }
+      }
+    }
+
+    if (inputs['max-attempts']) {
+      clientConfiguration = {
+        ...clientConfiguration,
+        ...{ maxAttempts: inputs['max-attempts'] }
+      }
+    }
+
+    if (inputs['retry-mode']) {
+      clientConfiguration = {
+        ...clientConfiguration,
+        ...{ retryMode: inputs['retry-mode'] }
       }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,24 @@ export function parseParameters(
   })
 }
 
+export function parseRetryMode(
+  s?: string
+): 'standard' | 'adaptive' | undefined {
+  const parsed = parseString(s)
+
+  if (!parsed) {
+    return undefined
+  }
+
+  if (parsed === 'standard' || parsed === 'adaptive') {
+    return parsed
+  }
+
+  throw new Error(
+    `Invalid retry-mode: ${parsed}. Supported values: 'standard', 'adaptive'.`
+  )
+}
+
 export function parseDeploymentMode(s: string): 'REVERT_DRIFT' | undefined {
   const parsed = parseString(s)
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -4,7 +4,8 @@ import {
   parseNumber,
   parseTags,
   parseParameters,
-  parseBoolean
+  parseBoolean,
+  parseRetryMode
 } from './utils'
 
 // Helper transformers
@@ -16,7 +17,9 @@ const baseSchema = z.object({
     .enum(['create-and-execute', 'create-only', 'execute-only'])
     .default('create-and-execute'),
   name: z.string().min(1, 'Stack name is required'),
-  'http-proxy': z.string().optional().transform(emptyToUndefined)
+  'http-proxy': z.string().optional().transform(emptyToUndefined),
+  'max-attempts': z.string().optional().transform(parseNumber),
+  'retry-mode': z.string().optional().transform(parseRetryMode)
 })
 
 const createSchema = baseSchema.extend({


### PR DESCRIPTION
## Summary
- Adds `max-attempts` and `retry-mode` as action input parameters to configure AWS SDK retry behavior
- Passes these values to the `CloudFormationClient` (and `S3Client`) constructor config
- Allows users to control retry behavior without relying on `AWS_MAX_ATTEMPTS` and `AWS_RETRY_MODE` environment variables, which are global and can bleed into other workflow steps

## Motivation
There was no way to configure the SDK-level retry behavior from the action inputs. Users had to set environment variables outside the action context, which is not discoverable and affects the entire job.

## Changes
- `action.yml`: Added `max-attempts` and `retry-mode` input definitions
- `src/utils.ts`: Added `parseRetryMode()` validator (accepts `'standard'` or `'adaptive'`)
- `src/validation.ts`: Added both fields to the base schema (applies to all modes)
- `src/main.ts`: Reads inputs and sets `maxAttempts`/`retryMode` on the shared client configuration

## Test plan
- [x] All existing tests pass (212 tests, 6 suites)
- [x] TypeScript compiles without errors
- [x] `dist/index.js` rebuilt successfully
- [ ] Verify with a workflow using `max-attempts: 10` and `retry-mode: adaptive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------------------------------------------------------------------------------
Please notice that although i created this PR using Claude Code i did review the changes myself and the need for this feature is real. Highly parallelized stack deployment can cause issues with Rate Excceeded errors.